### PR TITLE
Fix: support isabelle-client 1.1.0 Pydantic responses

### DIFF
--- a/prover/cli.py
+++ b/prover/cli.py
@@ -235,7 +235,12 @@ def main():
         server_info, proc = start_isabelle_server(name="isabelle", log_file="server.log")
         print(server_info.strip())
         isabelle = get_isabelle_client(server_info)
-        session_id = isabelle.session_start(session="HOL")
+        # isabelle-client 1.1.0 returns a list of response objects; extract the id.
+        _ss_resp = isabelle.session_start(session="HOL")
+        session_id = (
+            _ss_resp[-1].response_body.session_id
+            if isinstance(_ss_resp, list) else _ss_resp
+        )
         print("session_id:", session_id)
 
         # Mine macros from existing logs (fast; skips if file missing)

--- a/prover/isabelle_api.py
+++ b/prover/isabelle_api.py
@@ -73,16 +73,30 @@ def _normalize_type(rt: Any) -> str:
 
 
 def _decode_body_to_dict(body: Any) -> Optional[Dict[str, Any]]:
-    """Body may be dict/JSON string/bytes; return dict or None."""
+    """Body may be dict, JSON string, bytes, or a Pydantic model (isabelle-client>=1.1)."""
     if body is None:
         return None
+    if isinstance(body, dict):
+        return body
+    # Pydantic v2 model (e.g. UseTheoriesResults from isabelle-client 1.1.0)
+    dump = getattr(body, "model_dump", None)
+    if callable(dump):
+        try:
+            return dump()
+        except Exception:
+            pass
+    # Pydantic v1 model
+    d = getattr(body, "dict", None)
+    if callable(d):
+        try:
+            return d()
+        except Exception:
+            pass
     if isinstance(body, (bytes, bytearray)):
         try:
             body = body.decode("utf-8", "replace")
         except Exception:
             body = str(body)
-    if isinstance(body, dict):
-        return body
     try:
         return json.loads(body)
     except Exception:


### PR DESCRIPTION
## Summary
With the current `requirements.txt`, `pip install` pulls **isabelle-client 1.1.0**, whose API returns Pydantic model instances (`UseTheoriesResults`, `SessionStartRegularResponse`, …) instead of the JSON strings / dicts the repo was written against. Two bugs result:

1. **Every proof silently fails.** `prover/isabelle_api.py::_decode_body_to_dict` only understands `dict` / `bytes` / JSON-string bodies. For a Pydantic body it falls through to `json.loads(<model>)`, raises, and returns `None`. `finished_ok` then can't see `ok=True`, so every successful `use_theories` call is treated as a failure. The user-visible symptom is *every* tactic — including textbook ones like `by simp` on `rev (rev xs) = xs` — failing with uniform ~2 s latency.

2. **Crash at startup in `prover.cli`.** `session_start()` now returns a list of response objects, and the raw list was being passed as `session_id` into subsequent calls, producing `TypeError: Object of type TaskOK is not JSON serializable` from `isabelle_client.execute_command`.

## Repro (before fix)
```bash
python -m prover.cli --goal 'rev (rev xs) = xs' \
  --model 'gemini:gemini-3-flash-preview' --trace --timeout 120
# ...
# Finishers (origin): [llm:by simp, llm:by auto, llm:by (induct xs) auto, ...]
#   finish × [llm] by simp  (2276ms)
#   finish × [llm] by auto  (2091ms)
#   finish × [llm] by (induct xs) auto  (2110ms)
#   ...
# FAILED | depth: 1
```
Instrumenting `finished_ok` confirms Isabelle actually returns `UseTheoriesResults(ok=True, errors=[], nodes=[NodeResult(... ok=True, finished=8 ...)])` — every tactic succeeded; the parser just couldn't see it.

## Fix
- `prover/isabelle_api.py`: `_decode_body_to_dict` now calls `model_dump()` (Pydantic v2) or `dict()` (v1) when the body is a model, before falling through to the existing JSON / bytes paths. Older clients remain fully supported.
- `prover/cli.py`: extract `session_id` from the list returned by `session_start()`, with an `isinstance(_, list)` guard so older clients that return a string still work.

## After
```
SUCCESS | depth: 1
lemma "rev (rev xs) = xs"
by simp
```

## Environment
- macOS (Apple Silicon), Isabelle2025-2
- Python 3.12.13, `isabelle-client==1.1.0`
- Backend: `gemini-cli` (`gemini:gemini-3-flash-preview`)

## Follow-up (not in this PR)
The same `session_start()` list-vs-string assumption exists in `planner/experiments.py`, `planner/driver.py`, `prover/experiments.py`, and `isabelle_ui/server.py`. Kept this PR focused on the `prover.cli` path that I actually verified end-to-end — happy to send a follow-up that applies the same defensive extraction across those call sites if you'd like.